### PR TITLE
Avoid raising when no ci runs available

### DIFF
--- a/src/docker_publisher_osparc_services/http_interface.py
+++ b/src/docker_publisher_osparc_services/http_interface.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict, Optional, Set
+import logging
 
 from httpx import AsyncClient, codes
 from yarl import URL
@@ -7,6 +8,8 @@ from yarl import URL
 from .exceptions import CouldNotFindAGitlabRepositoryRepoException
 from .models import RegistryEndpointModel, RepoModel
 
+
+_logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def async_client(timeout: float = 30, **kwargs) -> AsyncIterator[AsyncClient]:
@@ -39,7 +42,8 @@ async def github_did_last_repo_run_pass(
             url = result.links.get("next", {}).get("url")
 
         if associated_run is None:
-            raise Exception(f"Could not find associated run to commit {branch_hash}")
+            _logger.warning(f"Could not find associated run to commit {branch_hash}")
+            return False
 
         return (
             associated_run["status"] == "completed"


### PR DESCRIPTION
Don't raise exception when there are no Github CI runs. Raising causes the publishing of services to fail when a single ci run for a single service is not available (https://git.speag.com/oSparc/docker-publisher-osparc-services/-/jobs/9783934). It seems Github cleans up CI runs occasionally.

@GitHK probably this should be handled by requiring services to create Github releases and tag release branches/commits accordingly, then the artifacts should always be available. 

- related Github issue: #5 